### PR TITLE
feat(score-and-goal): add goal area, display health and update as enemies reach goal

### DIFF
--- a/Enemies/TemplateEnemy.gd
+++ b/Enemies/TemplateEnemy.gd
@@ -11,7 +11,7 @@ export var debug_mode = false setget set_debug
 const ARRIVAL_BUFFER = 10
 const SPEED = 3
 
-signal reached_goal
+signal reached_goal(damage)
 
 func set_debug(val: bool):
 	debug_mode = val
@@ -44,5 +44,6 @@ func update_path():
 	next_destination_idx = 0
 
 func handle_goal_arrival():
-	emit_signal("reached_goal")
+#	print_debug("reached goal inside enemy")
+	emit_signal("reached_goal", 1)
 	queue_free()

--- a/Enemies/TemplateEnemy.gd
+++ b/Enemies/TemplateEnemy.gd
@@ -1,5 +1,7 @@
 extends KinematicBody2D
 
+class_name TemplateEnemy
+
 onready var goal = get_tree().root.find_node("Goal", true, false).global_position
 var path: PoolVector2Array
 var next_destination_idx
@@ -8,6 +10,8 @@ export var debug_mode = false setget set_debug
 
 const ARRIVAL_BUFFER = 10
 const SPEED = 3
+
+signal reached_goal
 
 func set_debug(val: bool):
 	debug_mode = val
@@ -40,4 +44,5 @@ func update_path():
 	next_destination_idx = 0
 
 func handle_goal_arrival():
+	emit_signal("reached_goal")
 	queue_free()

--- a/levels/Goal.tscn
+++ b/levels/Goal.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=2 format=2]
+
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 64, 96 )
+
+[node name="Goal" type="Area2D"]
+
+[node name="ColorRect" type="ColorRect" parent="."]
+margin_left = -128.0
+margin_top = -96.0
+margin_bottom = 96.0
+color = Color( 0.266667, 0.247059, 0.247059, 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2( -64, 0 )
+shape = SubResource( 1 )

--- a/levels/TemplateLevel.gd
+++ b/levels/TemplateLevel.gd
@@ -1,8 +1,13 @@
 extends Node2D
 
+onready var score_label = $ScoreLabel
 var TowerPlacement = preload("res://levels/TowerPlacement.tscn")
 var is_grid_on = false
 export var placement_mode = false
+export var lives = 3
+
+func _ready(): 
+	update_score_label(lives)
 
 func _process(_delta):
 	if (placement_mode):
@@ -18,3 +23,20 @@ func place_tower(position, tower):
 	new_tower.position = position
 	$Towers.add_child(new_tower)
 	$Navigation.update_nav_area()
+
+func update_score_label(score):
+	score_label.text = "LIVES LEFT: " + str(score)
+
+func _on_Goal_area_entered(area):
+	if area is TemplateEnemy:
+		print_debug("enemy reached goal!")
+		lives -= lives
+		update_score_label(lives)
+
+
+func _on_Enemy_reached_goal():
+	print_debug("enemy reached goal!")
+	lives -= 1
+	if (lives <= 0):
+		get_tree().quit()
+	update_score_label(lives)

--- a/levels/TemplateLevel.gd
+++ b/levels/TemplateLevel.gd
@@ -1,9 +1,14 @@
 extends Node2D
 
+onready var score_label = $ScoreLabel
 var TowerPlacement = preload("res://levels/TowerPlacement.tscn")
 var enemy = preload("res://Enemies/TemplateEnemy.tscn")
 var is_grid_on = false
 export var placement_mode = false
+export var lives = 3
+
+func _ready(): 
+	update_score_label(lives)
 
 func _process(_delta):
 	if (placement_mode):
@@ -20,9 +25,18 @@ func place_tower(position, tower):
 	$Towers.add_child(new_tower)
 	$Navigation.update_nav_area()
 
-
 func spawn_enemy(position):
 	var new_enemy = enemy.instance()
 	new_enemy.position = position
 	new_enemy.debug_mode = true
 	$Enemies.add_child(new_enemy)
+
+func update_score_label(score):
+	score_label.text = "LIVES LEFT: " + str(score)
+
+func _on_Enemy_reached_goal():
+	print_debug("enemy reached goal!")
+	lives -= 1
+	if (lives <= 0):
+		get_tree().quit()
+	update_score_label(lives)

--- a/levels/TemplateLevel.gd
+++ b/levels/TemplateLevel.gd
@@ -5,10 +5,11 @@ var TowerPlacement = preload("res://levels/TowerPlacement.tscn")
 var enemy = preload("res://Enemies/TemplateEnemy.tscn")
 var is_grid_on = false
 export var placement_mode = false
-export var lives = 3
+export var health = 3
 
 func _ready(): 
-	update_score_label(lives)
+	randomize()
+	update_score_label(health)
 
 func _process(_delta):
 	if (placement_mode):
@@ -16,6 +17,7 @@ func _process(_delta):
 	else:
 		$TowerPlacement.hide()
 
+# debug / dev function
 func _on_PlacementModeButton_toggled(placement_mode_toggle):
 	placement_mode = placement_mode_toggle
 
@@ -30,13 +32,19 @@ func spawn_enemy(position):
 	new_enemy.position = position
 	new_enemy.debug_mode = true
 	$Enemies.add_child(new_enemy)
+	if new_enemy.has_signal("reached_goal"):
+		new_enemy.connect("reached_goal", self, "_on_Enemy_reached_goal")
 
 func update_score_label(score):
-	score_label.text = "LIVES LEFT: " + str(score)
+	score_label.text = "HP: " + str(score)
 
-func _on_Enemy_reached_goal():
-	print_debug("enemy reached goal!")
-	lives -= 1
-	if (lives <= 0):
+func _on_Enemy_reached_goal(damage):
+	print("enemy reached goal!")
+	health -= damage
+	update_score_label(health)
+	if (health <= 0):
 		get_tree().quit()
-	update_score_label(lives)
+
+# debug / dev function
+func _on_SpawnEnemyButton_pressed():
+	spawn_enemy(Vector2(1568, clamp(randi() % 1025, 0, 1024)))

--- a/levels/TemplateLevel.tscn
+++ b/levels/TemplateLevel.tscn
@@ -78,7 +78,7 @@ outlines = [ PoolVector2Array( 0, 0, 16, 0, 16, 16, 0, 16 ) ]
 
 [node name="TemplateLevel" type="Node2D"]
 script = ExtResource( 6 )
-lives = 1
+health = 10
 
 [node name="BackgroundTileMap" type="TileMap" parent="."]
 tile_set = SubResource( 1 )
@@ -129,7 +129,7 @@ size_flags_vertical = 3
 border_width = 1.4
 editor_only = false
 
-[node name="CheckButton" type="CheckButton" parent="CanvasLayer"]
+[node name="PlacementModeButton" type="CheckButton" parent="CanvasLayer"]
 margin_left = 697.0
 margin_top = 869.0
 margin_right = 773.0
@@ -140,6 +140,13 @@ custom_colors/font_color = Color( 0, 0, 0, 1 )
 custom_colors/font_color_hover = Color( 0, 0, 0, 1 )
 custom_colors/font_color_pressed = Color( 0, 0, 0, 1 )
 text = "Placement Mode"
+
+[node name="SpawnEnemyButton" type="Button" parent="CanvasLayer"]
+margin_left = 498.0
+margin_top = 881.0
+margin_right = 597.0
+margin_bottom = 901.0
+text = "Spawn Enemy"
 
 [node name="Towers" type="Node" parent="."]
 
@@ -159,13 +166,14 @@ debug_mode = true
 position = Vector2( 128, 416 )
 
 [node name="ScoreLabel" type="Label" parent="."]
-margin_left = 15.0
-margin_top = 406.0
-margin_right = 105.0
-margin_bottom = 420.0
-text = "LIVES LEFT: 10"
+margin_left = 17.0
+margin_top = 410.0
+margin_right = 107.0
+margin_bottom = 424.0
+text = "HP: 10"
+align = 1
 
-[connection signal="toggled" from="CanvasLayer/CheckButton" to="." method="_on_PlacementModeButton_toggled"]
+[connection signal="toggled" from="CanvasLayer/PlacementModeButton" to="." method="_on_PlacementModeButton_toggled"]
+[connection signal="pressed" from="CanvasLayer/SpawnEnemyButton" to="." method="_on_SpawnEnemyButton_pressed"]
 [connection signal="reached_goal" from="Enemies/TemplateEnemy" to="." method="_on_Enemy_reached_goal"]
 [connection signal="place_tower" from="TowerPlacement" to="." method="place_tower"]
-[connection signal="area_entered" from="Goal" to="." method="_on_Goal_area_entered"]

--- a/levels/TemplateLevel.tscn
+++ b/levels/TemplateLevel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://assets/GFX/wood/horizontal/wood5_horizontal.png" type="Texture" id=1]
 [ext_resource path="res://assets/GFX/wood/horizontal/wood1_horizontal.png" type="Texture" id=2]
@@ -8,6 +8,7 @@
 [ext_resource path="res://levels/TemplateLevel.gd" type="Script" id=6]
 [ext_resource path="res://levels/Navigation.gd" type="Script" id=7]
 [ext_resource path="res://levels/TowerPlacement.tscn" type="PackedScene" id=8]
+[ext_resource path="res://levels/Goal.tscn" type="PackedScene" id=9]
 
 [sub_resource type="TileSet" id=1]
 0/name = "LightWood"
@@ -77,6 +78,7 @@ outlines = [ PoolVector2Array( 0, 0, 16, 0, 16, 16, 0, 16 ) ]
 
 [node name="TemplateLevel" type="Node2D"]
 script = ExtResource( 6 )
+lives = 1
 
 [node name="BackgroundTileMap" type="TileMap" parent="."]
 tile_set = SubResource( 1 )
@@ -151,10 +153,19 @@ collision_mask = 0
 position = Vector2( 1344, 320 )
 debug_mode = true
 
-[node name="Goal" type="Node2D" parent="."]
-position = Vector2( 64, 576 )
-
 [node name="TowerPlacement" parent="." instance=ExtResource( 8 )]
 
+[node name="Goal" parent="." instance=ExtResource( 9 )]
+position = Vector2( 128, 416 )
+
+[node name="ScoreLabel" type="Label" parent="."]
+margin_left = 15.0
+margin_top = 406.0
+margin_right = 105.0
+margin_bottom = 420.0
+text = "LIVES LEFT: 10"
+
 [connection signal="toggled" from="CanvasLayer/CheckButton" to="." method="_on_PlacementModeButton_toggled"]
+[connection signal="reached_goal" from="Enemies/TemplateEnemy" to="." method="_on_Enemy_reached_goal"]
 [connection signal="place_tower" from="TowerPlacement" to="." method="place_tower"]
+[connection signal="area_entered" from="Goal" to="." method="_on_Goal_area_entered"]

--- a/project.godot
+++ b/project.godot
@@ -8,6 +8,16 @@
 
 config_version=4
 
+_global_script_classes=[ {
+"base": "KinematicBody2D",
+"class": "TemplateEnemy",
+"language": "GDScript",
+"path": "res://Enemies/TemplateEnemy.gd"
+} ]
+_global_script_class_icons={
+"TemplateEnemy": ""
+}
+
 [application]
 
 config/name="Chelydra"


### PR DESCRIPTION
HOW EXCITING.

- Added a rectangular goal area on the left hand side of the grid
- Added health display on the "phone" goal area that updates and deducts the appropriate amount of damage when the enemy reaches it
- Enemies should emit a signal `reached_goal(damage)` when their goal is reached and pass the amount of damage to be taken by the player
- Added a dev button on the UI to spawn a new enemy at a random point on the right hand side of the grid for testing
- Exported a var for player `Health` that can be adjusted on the level. The default is `10`
- Game automatically quits when all health is lost!

[Video Demo !](https://drive.google.com/file/d/1Exy9A0iFRCOq257aoXUwSNY6JXBRcJQ1/view?usp=sharing)
